### PR TITLE
Forwardable is used but not required

### DIFF
--- a/lib/product.rb
+++ b/lib/product.rb
@@ -3,6 +3,7 @@ require_relative 'category/movie'
 require_relative 'category/unknown'
 require 'nokogiri'
 require 'open-uri'
+require 'forwardable'
 
 class Product
   extend Forwardable


### PR DESCRIPTION
specs pass as rspec seams to require it for internal use

without requiring it I get:

``` shell
$ ./bin/amazon_crawler.rb
/Users/duksis/code/amazon-parser/lib/product.rb:8:in `<class:Product>': uninitialized constant Product::Forwardable (NameError)
        from /Users/duksis/code/amazon-parser/lib/product.rb:7:in `<top (required)>'
        from ./bin/amazon_crawler.rb:2:in `require_relative'
        from ./bin/amazon_crawler.rb:2:in `<main>'
```
